### PR TITLE
AB2015 Drupal kursu asil ve yedek katilimci listesi

### DIFF
--- a/drupal_asil.txt
+++ b/drupal_asil.txt
@@ -1,0 +1,14 @@
+Hilal Seda Yıldız
+Hüseyin İlhan
+Erdal Ayan
+Gülay Mehmetlioğlu
+Emre Engin
+Barış Sezen
+Umut Tunalı
+Dursun Çimen
+Hasan Uçar
+Ömer Faruk Demirer
+Halime Kardaş
+Elif Tepe
+Sami Çiçekli
+Ali Tat

--- a/drupal_yedek.txt
+++ b/drupal_yedek.txt
@@ -1,0 +1,2 @@
+Gülbin Kurtay
+Sadık Tekgöz


### PR DESCRIPTION
Akademik Bilişim 2015 kapsamında düzenlenen "Eğitim Kurumları için Drupal" isimli kursun asıl ve yedek katılımcı listesi.
