### PR TITLE
Drupal kursu guncellenmis asil ve yedek katılimci listesi

### DIFF
--- a/drupal_asil.txt
+++ b/drupal_asil.txt
@@ -1,14 +1,14 @@
-Hilal Seda Yıldız
-Hüseyin İlhan
-Erdal Ayan
-Gülay Mehmetlioğlu
-Emre Engin
-Barış Sezen
-Umut Tunalı
-Dursun Çimen
-Hasan Uçar
-Ömer Faruk Demirer
-Halime Kardaş
-Elif Tepe
-Sami Çiçekli
-Ali Tat
+hilal-seda-yıldız
+hüseyin-ilhan
+erdal-ayan
+gülay-mehmetlioğlu
+emre-engin
+barış-sezen
+umut-tunalı
+dursun-çimen
+hasan-uçar
+ömer-faruk-demirer
+halime-kardaş
+elif-tepe
+sami-çiçekli
+demet-ergenoğlu

--- a/drupal_yedek.txt
+++ b/drupal_yedek.txt
@@ -1,2 +1,3 @@
-Gülbin Kurtay
-Sadık Tekgöz
+ali-tat
+gülbin-kurtay
+sadık-tekgöz


### PR DESCRIPTION
Demet Ergenoğlu isimli katılımcı birinci veya ikinci tercihte Drupal kursunu yazmamış ama özel olarak rica ettiğinden, kurs ön koşullarına uyduğundan ve kursta yer olduğundan kabul ettim.

Katılımcının birinci tercihi Web Erişebilirlik.

Ali Tat ise yedek listelere aktarıldı. Gelip gelemeyeceği kesin değilmiş (%90 olarak bahsetti) ve ben de sorun çıkmaması için yedek listeye aktardım.
