### PR TITLE
Guncellenen Drupal yedek ve asil katilimci listesi

### DIFF
--- a/drupal_asil.txt
+++ b/drupal_asil.txt
@@ -12,3 +12,9 @@ halime-kardaş
 elif-tepe
 sami-çiçekli
 demet-ergenoğlu
+gülbin-kurtay
+könül-memmedova
+ismet-safa-develi
+orhan-özcan
+nur-gizem-ak
+ali-tat

--- a/drupal_yedek.txt
+++ b/drupal_yedek.txt
@@ -1,3 +1,2 @@
-ali-tat
-gülbin-kurtay
 sadık-tekgöz
+ömer-faruk-sunar


### PR DESCRIPTION
Birkaç gün içinde benimle doğrudan iletişime geçen kişilerden, Drupal kursu ön koşullarına uygun olanlarını listeye ekledim. Notlarım aşağıdadır:
- **Gülbin Kurtay**'ın 2. tercihi Drupal idi.
- **Ali Tat**'ın özel bir durumu varmış ama kendisinden onay alarak asıl listeye aktardım. Gelemeyecek durumda olursa, evrakları ile AB yönetimine başvuracak.
- Diğer katılımcıların 1. veya 2. tercihi Drupal değildi, ama kabul aldıkları kursların eğitmenlerinden onay aldıktan sonra Drupal kursuna katılmalarını kabul ettim. Bu kişiler ve detayları aşağıdadır:

**Web Erişilebilirlik kursundan Drupal kursuna geçenler:**
- Elif Tepe
- Demet Ergenoğlu

**Javascript kursundan Drupal kursuna geçenler:**
- Könül Memmedova
- Nur Gizem Ak
- İsmet Safa Develi

**Blender kursundan Drupal kursuna geçenler:**
- Orhan Özcan

**Java kursundan Drupal kursuna geçmeyi isteyenler:**
- Ömer Faruk Sunar (kendisinden henüz yanıt alamadığımdan yedek listeye ekledim)
