### PR TITLE
2 yeni kursiyer eklendi.

### DIFF
--- a/ruby_on_rails_101.txt
+++ b/ruby_on_rails_101.txt
@@ -26,3 +26,5 @@ Yunus ÖZDEN
 Zinnur YEŞİLYURT
 Emre BEGEN
 Raif SİME
+Cankat Akdemir
+Ali Gündogdu


### PR DESCRIPTION
ikinci tercihleri Ruby on Rails 101 olan Cankat Akdemir ve Ali Gündoğdu adlı kursiyeler talepleri uzerine Ruby on Rails 101 kabul listesine eklendi.
